### PR TITLE
Fix createsuperuser command

### DIFF
--- a/credits/models.py
+++ b/credits/models.py
@@ -1,5 +1,9 @@
+import sys
+
 from django.contrib.auth.models import User
 from django.db import models
+
+TESTING = ('test' in sys.argv)
 
 
 class Profile(models.Model):
@@ -15,7 +19,8 @@ class Profile(models.Model):
 
 
 def user_post_save(sender, instance, created, raw, **kwargs):
-    if created:
+    # Use this table only when testing
+    if created and TESTING:
         Profile.objects.create(user=instance)
 
 


### PR DESCRIPTION
- There is a Profile model in credits app that is only used for tests. If you run createsuperuser command, then an error is shown because you aren't testing and that table doesn't exists.
- Fix in the function to be executed only in the `test` command.