### PR TITLE
Add EMAIL_BACKEND config to test drips locally

### DIFF
--- a/testsettings.py
+++ b/testsettings.py
@@ -66,3 +66,5 @@ ROOT_URLCONF = 'test_urls'
 
 STATIC_URL = '/static/'
 STATICFILES_DIRS = ()
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
- Now, we can't test locally the command `send_drips` to send the emails. The error is `Connection refused`.
- I added EMAIL_BACKEND config in testing, in order to see the emails in the console.