### PR TITLE
fix: change unicode to str as python3 supports

### DIFF
--- a/drip/models.py
+++ b/drip/models.py
@@ -64,7 +64,7 @@ class Drip(models.Model):
         )
         return drip
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 


### PR DESCRIPTION
Reference https://docs.djangoproject.com/en/1.8/topics/python3/#str-and-unicode-methods