### PR TITLE
Fix pypi images

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If you haven't, create a superuser with the [Django createsuperuser command](htt
 
 In the Django admin, after select `Drips`, you can click on `ADD DRIP +` button to create a new one. You will see the `add drip` page:
 
-<img src="docs/images/add_drip_page.png" alt="Add Drip" width="700" />
+<img src="https://github.com/rootstrap/django-drip-campaigns/blob/master/docs/images/add_drip_page.png" alt="Add Drip" width="700" />
 
 On the `FIELD NAME OF USER` input, when you click on it, you will be able to view:
 
@@ -58,7 +58,7 @@ On the `FIELD NAME OF USER` input, when you click on it, you will be able to vie
 
 Please take a look a this example:
 
-<img src="docs/images/users_lookup_fields.png" alt="User's fields" width="700" />
+<img src="https://github.com/rootstrap/django-drip-campaigns/blob/master/docs/images/users_lookup_fields.png" alt="Lookup Fields" width="700" />
 
 With this, you can select one or more fields to create useful drips.  
 Additionally if you select a field name of user that has a date type, you can enter in the `FIELD VALUE` input, a date value written in natural language that combines operations on the current datetime.  
@@ -100,7 +100,7 @@ Let's see some examples of the date values that you can enter:
 
 In the Django admin, you can select a drip and then click on the `VIEW TIMELINE` button to view the mails expected to be sent with the corresponding receivers:
 
-<img src="docs/images/view_timeline.png" alt="View Timeline" width="350" />
+<img src="https://github.com/rootstrap/django-drip-campaigns/blob/master/docs/images/view_timeline.png" alt="Timeline" width="350" />
 
 ### Send drips
 


### PR DESCRIPTION
closes #49 

Images in README are imported differently so documentation generated for pypi can show them on the pypi page