### PR TITLE
Normalize f-strings across code base

### DIFF
--- a/drip/admin.py
+++ b/drip/admin.py
@@ -15,7 +15,7 @@ class QuerySetRuleInline(admin.TabularInline):
 class DripForm(forms.ModelForm):
     message_class = forms.ChoiceField(
         choices=(
-            (k, f'{k} ({v})')
+            (k, '{k} ({v})'.format(k=k, v=v))
             for k, v in configured_message_classes().items()
         ),
     )

--- a/drip/admin.py
+++ b/drip/admin.py
@@ -15,7 +15,7 @@ class QuerySetRuleInline(admin.TabularInline):
 class DripForm(forms.ModelForm):
     message_class = forms.ChoiceField(
         choices=(
-            (k, '%s (%s)' % (k, v))
+            (k, f'{k} ({v})')
             for k, v in configured_message_classes().items()
         ),
     )

--- a/drip/drips.py
+++ b/drip/drips.py
@@ -97,7 +97,7 @@ class DripMessage(object):
         if self.drip_base.from_email_name:
             from_ = "{name} <{email}>".format(
                 name=self.drip_base.from_email_name,
-                email=self.drip_base.from_email
+                email=self.drip_base.from_email,
             )
         else:
             from_ = self.drip_base.from_email
@@ -290,7 +290,7 @@ class DripBase(object):
                     "Failed to send drip {drip} to user {user}: {err}".format(
                         drip=self.drip_model.id,
                         user=str(user),
-                        err=str(e)
+                        err=str(e),
                     )
                 )
         return count

--- a/drip/drips.py
+++ b/drip/drips.py
@@ -95,7 +95,10 @@ class DripMessage(object):
 
     def get_from_(self):
         if self.drip_base.from_email_name:
-            from_ = f"{self.drip_base.from_email_name} <{self.drip_base.from_email}>"
+            from_ = (
+                f"{self.drip_base.from_email_name} "
+                f"<{self.drip_base.from_email}>"
+            )
         else:
             from_ = self.drip_base.from_email
         return from_
@@ -284,7 +287,8 @@ class DripBase(object):
                     count += 1
             except Exception as e:
                 logging.error(
-                    f"Failed to send drip {self.drip_model.id} to user {str(user)}: {str(e)}"
+                    f"Failed to send drip {self.drip_model.id} to user "
+                    f"{str(user)}: {str(e)}"
                 )
         return count
 

--- a/drip/drips.py
+++ b/drip/drips.py
@@ -95,9 +95,9 @@ class DripMessage(object):
 
     def get_from_(self):
         if self.drip_base.from_email_name:
-            from_ = (
-                f"{self.drip_base.from_email_name} "
-                f"<{self.drip_base.from_email}>"
+            from_ = "{name} <{email}>".format(
+                name=self.drip_base.from_email_name,
+                email=self.drip_base.from_email
             )
         else:
             from_ = self.drip_base.from_email
@@ -287,8 +287,11 @@ class DripBase(object):
                     count += 1
             except Exception as e:
                 logging.error(
-                    f"Failed to send drip {self.drip_model.id} to user "
-                    f"{str(user)}: {str(e)}"
+                    "Failed to send drip {drip} to user {user}: {err}".format(
+                        drip=self.drip_model.id,
+                        user=str(user),
+                        err=str(e)
+                    )
                 )
         return count
 

--- a/drip/drips.py
+++ b/drip/drips.py
@@ -95,10 +95,7 @@ class DripMessage(object):
 
     def get_from_(self):
         if self.drip_base.from_email_name:
-            from_ = "%s <%s>" % (
-                self.drip_base.from_email_name,
-                self.drip_base.from_email,
-            )
+            from_ = f"{self.drip_base.from_email_name} <{self.drip_base.from_email}>"
         else:
             from_ = self.drip_base.from_email
         return from_
@@ -287,8 +284,7 @@ class DripBase(object):
                     count += 1
             except Exception as e:
                 logging.error(
-                    "Failed to send drip %s to user %s: %s" %
-                    (self.drip_model.id, user, e)
+                    f"Failed to send drip {self.drip_model.id} to user {str(user)}: {str(e)}"
                 )
         return count
 

--- a/drip/helpers.py
+++ b/drip/helpers.py
@@ -5,7 +5,7 @@ STRFDATETIME = re.compile('([dgGhHis])')
 
 
 def STRFDATETIME_REPL(x):
-    return '%%(%s)s' % x.group()
+    return f'%({x.group()})s'
 
 
 def process_regex(d):

--- a/drip/helpers.py
+++ b/drip/helpers.py
@@ -28,7 +28,7 @@ def get_flexible_regex(string):
         string,
     )
     if not d:
-        raise TypeError("'%s' is not a valid time interval" % string)
+        raise TypeError(f"'{string}' is not a valid time interval")
     d = d.groupdict(0)
     return d
 
@@ -55,5 +55,5 @@ def parse(string):
     string = string.strip()
 
     if string == "":
-        raise TypeError("'%s' is not a valid time interval" % string)
+        raise TypeError(f"'{string}' is not a valid time interval")
     return process_string(string)

--- a/drip/helpers.py
+++ b/drip/helpers.py
@@ -5,7 +5,7 @@ STRFDATETIME = re.compile('([dgGhHis])')
 
 
 def STRFDATETIME_REPL(x):
-    return f'%({x.group()})s'
+    return '%({group})s'.format(group=x.group())
 
 
 def process_regex(d):
@@ -28,7 +28,9 @@ def get_flexible_regex(string):
         string,
     )
     if not d:
-        raise TypeError(f"'{string}' is not a valid time interval")
+        raise TypeError(
+            "'{string}' is not a valid time interval".format(string=string)
+            )
     d = d.groupdict(0)
     return d
 
@@ -55,5 +57,7 @@ def parse(string):
     string = string.strip()
 
     if string == "":
-        raise TypeError(f"'{string}' is not a valid time interval")
+        raise TypeError(
+            "'{string}' is not a valid time interval".format(string=string)
+            )
     return process_string(string)

--- a/drip/models.py
+++ b/drip/models.py
@@ -158,7 +158,7 @@ class QuerySetRule(models.Model):
             raise ValidationError(
                 '{type_name} raised trying to apply rule: {error}'.format(
                     type_name=type(e).__name__,
-                    error=str(e)
+                    error=str(e),
                 )
             )
 
@@ -167,7 +167,7 @@ class QuerySetRule(models.Model):
         field_name = self.field_name
         if field_name.endswith('__count'):
             agg, _, _ = field_name.rpartition('__')
-            field_name = "num_{agg}".format(agg=agg.replace('__', '_'))
+            field_name = 'num_{agg}'.format(agg=agg.replace('__', '_'))
 
         return field_name
 

--- a/drip/models.py
+++ b/drip/models.py
@@ -156,7 +156,7 @@ class QuerySetRule(models.Model):
             self.apply(User.objects.all())
         except Exception as e:
             raise ValidationError(
-                '%s raised trying to apply rule: %s' % (type(e).__name__, e)
+                f'{type(e).__name__} raised trying to apply rule: {str(e)}'
             )
 
     @property
@@ -164,7 +164,7 @@ class QuerySetRule(models.Model):
         field_name = self.field_name
         if field_name.endswith('__count'):
             agg, _, _ = field_name.rpartition('__')
-            field_name = 'num_%s' % agg.replace('__', '_')
+            field_name = f'num_{agg.replace('__', '_')}'
 
         return field_name
 

--- a/drip/models.py
+++ b/drip/models.py
@@ -164,7 +164,7 @@ class QuerySetRule(models.Model):
         field_name = self.field_name
         if field_name.endswith('__count'):
             agg, _, _ = field_name.rpartition('__')
-            field_name = f'num_{agg.replace('__', '_')}'
+            field_name = f"num_{agg.replace('__', '_')}"
 
         return field_name
 

--- a/drip/models.py
+++ b/drip/models.py
@@ -156,7 +156,10 @@ class QuerySetRule(models.Model):
             self.apply(User.objects.all())
         except Exception as e:
             raise ValidationError(
-                f'{type(e).__name__} raised trying to apply rule: {str(e)}'
+                '{type_name} raised trying to apply rule: {error}'.format(
+                    type_name=type(e).__name__,
+                    error=str(e)
+                )
             )
 
     @property
@@ -164,7 +167,7 @@ class QuerySetRule(models.Model):
         field_name = self.field_name
         if field_name.endswith('__count'):
             agg, _, _ = field_name.rpartition('__')
-            field_name = f"num_{agg.replace('__', '_')}"
+            field_name = "num_{agg}".format(agg=agg.replace('__', '_'))
 
         return field_name
 

--- a/drip/tests/test_drips.py
+++ b/drip/tests/test_drips.py
@@ -37,8 +37,8 @@ class DripsTestCase(TestCase):
 
         for i, name in enumerate(num_string):
             user = self.User.objects.create(
-                username='%s_25_credits_a_day' % name,
-                email='%s@test.com' % name,
+                username=f'{name}_25_credits_a_day',
+                email=f'{name}@test.com',
             )
             self.User.objects.filter(id=user.id).update(
                 date_joined=start - timedelta(days=i),
@@ -50,8 +50,8 @@ class DripsTestCase(TestCase):
 
         for i, name in enumerate(num_string):
             user = self.User.objects.create(
-                username='%s_no_credits' % name,
-                email='%s@test.com' % name,
+                username=f'{name}_no_credits',
+                email=f'{name}@test.com',
             )
             self.User.objects.filter(id=user.id).update(
                 date_joined=start - timedelta(days=i),
@@ -162,13 +162,13 @@ class DripsTestCase(TestCase):
             drip=model_drip,
             field_name='date_joined',
             lookup_type='lt',
-            field_value='now-{0} days'.format(shift_one),
+            field_value=f'now-{shift_one} days',
         )
         QuerySetRule.objects.create(
             drip=model_drip,
             field_name='date_joined',
             lookup_type='gte',
-            field_value='now-{0} days'.format(shift_two),
+            field_value=f'now-{shift_two} days',
         )
         return model_drip
 

--- a/drip/tests/test_drips.py
+++ b/drip/tests/test_drips.py
@@ -37,8 +37,8 @@ class DripsTestCase(TestCase):
 
         for i, name in enumerate(num_string):
             user = self.User.objects.create(
-                username=f'{name}_25_credits_a_day',
-                email=f'{name}@test.com',
+                username='{name}_25_credits_a_day'.format(name=name),
+                email='{name}@test.com'.format(name=name),
             )
             self.User.objects.filter(id=user.id).update(
                 date_joined=start - timedelta(days=i),
@@ -50,8 +50,8 @@ class DripsTestCase(TestCase):
 
         for i, name in enumerate(num_string):
             user = self.User.objects.create(
-                username=f'{name}_no_credits',
-                email=f'{name}@test.com',
+                username='{name}_no_credits'.format(name=name),
+                email='{name}@test.com'.format(name=name),
             )
             self.User.objects.filter(id=user.id).update(
                 date_joined=start - timedelta(days=i),
@@ -162,13 +162,13 @@ class DripsTestCase(TestCase):
             drip=model_drip,
             field_name='date_joined',
             lookup_type='lt',
-            field_value=f'now-{shift_one} days',
+            field_value='now-{shift_one} days'.format(shift_one=shift_one),
         )
         QuerySetRule.objects.create(
             drip=model_drip,
             field_name='date_joined',
             lookup_type='gte',
-            field_value=f'now-{shift_two} days',
+            field_value='now-{shift_two} days'.format(shift_two=shift_two),
         )
         return model_drip
 

--- a/drip/utils.py
+++ b/drip/utils.py
@@ -170,9 +170,7 @@ def give_model_field(full_field: str, Model: models.Model) -> tuple:
         if full_key == full_field:
             return full_key, name, _Model, _ModelField
 
-    raise Exception('Field key `{0}` not found on `{1}`.'.format(
-        full_field, Model.__name__),
-    )
+    raise Exception(f'Field key `{full_field}` not found on `{Model.__name__}`.')
 
 
 def get_simple_fields(Model, **kwargs):

--- a/drip/utils.py
+++ b/drip/utils.py
@@ -171,7 +171,10 @@ def give_model_field(full_field: str, Model: models.Model) -> tuple:
             return full_key, name, _Model, _ModelField
 
     raise Exception(
-        f'Field key `{full_field}` not found on `{Model.__name__}`.'
+        'Field key `{field}` not found on `{model}`.'.format(
+            field=full_field,
+            model=Model.__name__
+        )
     )
 
 

--- a/drip/utils.py
+++ b/drip/utils.py
@@ -170,7 +170,9 @@ def give_model_field(full_field: str, Model: models.Model) -> tuple:
         if full_key == full_field:
             return full_key, name, _Model, _ModelField
 
-    raise Exception(f'Field key `{full_field}` not found on `{Model.__name__}`.')
+    raise Exception(
+        f'Field key `{full_field}` not found on `{Model.__name__}`.'
+    )
 
 
 def get_simple_fields(Model, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
     print("You probably want to also tag the version now:")
-    print("  git tag -a v%(version)s -m 'version v%(version)s'" % args)
+    print(f"  git tag -a v{args['version']} -m 'version v{args['version']}'")
     print("  git push --tags")
     sys.exit()
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
     print("You probably want to also tag the version now:")
-    print(f"  git tag -a v{args['version']} -m 'version v{args['version']}'")
+    print("  git tag -a v{v} -m 'version v{v}'".format(v=args['version']))
     print("  git push --tags")
     sys.exit()
 


### PR DESCRIPTION
close #41

This PR removes old `% string formating` and `str.format` in favor of `f-strings`

Except for:
[this snippet](https://github.com/markrofail/django-drip-campaigns/blob/5d8073a8640cc3978c2072976624660a7d7ee474/drip/helpers.py#L8)
```python
def STRFDATETIME_REPL(x):
    return '%%(%s)s' % x.group()
```
I don't understand it, my best shot was `return f"%{x.group()['%s']}"`