### PR TITLE
CC_TEST_REPORTER secret and stages added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ language: python
 dist: xenial
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8"
   - "pypy3"
+
+env:
+  global:
+    - CC_TEST_REPORTER_ID
 
 env:
   - DJANGO_VERSION="2.2"
@@ -19,11 +21,6 @@ install:
   - pip3 install flake8
   - pip install coverage
 
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
-
 script:
   # makemigrations of each app is needed
   - python manage.py makemigrations drip
@@ -33,11 +30,33 @@ script:
   - flake8 .
   - coverage run manage.py test
 
-after_script:
-  - coverage xml
-  - if [[ "$DJANGO_VERSION" == "3.0.7" && "$TRAVIS_PYTHON_VERSION" == "pypy3" ]]; then ./cc-test-reporter after-build -r 022c7b78c0d0c1af735f968d236d9a0691025b2c7746b5030522e07405084c9c --exit-code $TRAVIS_TEST_RESULT; fi
-
-matrix:
-  exclude:
-    - python: "3.5"
-      env: DJANGO_VERSION="3.0.7" #To use this version of django, a python version > 3.5 is needed
+jobs:
+  include:
+    - stage: Test 3.5-2.2
+      python:
+        - "3.5"
+      env:
+        - DJANGO_VERSION="2.2"
+    - stage: Test 3.8-2.2
+      python:
+        - "3.8"
+      env:
+        - DJANGO_VERSION="2.2"
+    - stage: Test Reporter
+      python:
+        - "3.8"
+      env:
+        - DJANGO_VERSION="3.0.7"
+      script:
+        - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        - chmod +x ./cc-test-reporter
+        - ./cc-test-reporter before-build
+        # makemigrations of each app is needed
+        - python manage.py makemigrations drip
+        - python manage.py makemigrations credits
+        - python manage.py makemigrations auth
+        - python manage.py migrate
+        - flake8 .
+        - coverage run manage.py test
+        - coverage xml
+        - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
Enhancement of travis to:
- Add stages for particular case of python 3.5 and Django 2.2.
- Separate python 3.8 and Django 3 to run test reporter. Stage added.
- CC_TEST_REPORTER is no longer visible. Now is used as a global virtual env.
- matrix is no longer needed


<img width="1000" alt="Screen Shot 2020-11-06 at 18 02 46" src="https://user-images.githubusercontent.com/20806762/98414534-4f07f880-205a-11eb-9cbc-dfea18b720e7.png">
 
