### PR TITLE
Fix error in installation docs

### DIFF
--- a/docs/source/content/installation.configuration.rst
+++ b/docs/source/content/installation.configuration.rst
@@ -19,7 +19,6 @@ Installation and configuration
         'django.contrib.admin',
         # ...
         'drip',
-        'campaigns',
     ]
 
 


### PR DESCRIPTION
## Description
Fix error in installation docs. There is an error in calling 'campaigns' folder app that it is not necessary anymore.


## Changes include
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change that solves an issue, bump the third digit of the version)
- [ ] New feature (non-breaking change that adds functionality, bump the second digit of the version)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality, bump the first digit of the version)
- [x] Documentation update (Don't bump the version of the project)

## Other comments
